### PR TITLE
chore: add locale, move logger to specific file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint": "^8.57.0",
         "eslint-plugin-prettier": "^5.2.1",
         "husky": "^9.1.3",
+        "i18next": "^23.12.2",
         "nodemon": "^3.1.4",
         "pino": "^9.3.2",
         "pino-pretty": "^11.2.2",
@@ -30,6 +31,18 @@
       },
       "engines": {
         "node": "20"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
+      "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1466,6 +1479,29 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/i18next": {
+      "version": "23.12.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.12.2.tgz",
+      "integrity": "sha512-XIeh5V+bi8SJSWGL3jqbTEBW5oD6rbP5L+E7dVQh1MNTxxYef0x15rhJVcRb7oiuq4jLtgy2SD8eFlf6P2cmqg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2280,6 +2316,12 @@
       "engines": {
         "node": ">= 12.13.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint": "^8.57.0",
     "eslint-plugin-prettier": "^5.2.1",
     "husky": "^9.1.3",
+    "i18next": "^23.12.2",
     "nodemon": "^3.1.4",
     "pino": "^9.3.2",
     "pino-pretty": "^11.2.2",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -2,23 +2,7 @@ import dotenv from "dotenv";
 import env from "env-var";
 import fs from "node:fs";
 import path from "node:path";
-import { pino } from "pino";
-
-/**
- * Logger object for better log messages
- */
-export const logger = pino({
-  transport: {
-    targets: [
-      { target: "pino-pretty" },
-      {
-        target: "pino/file",
-        options: { destination: `.log` },
-      },
-    ],
-  },
-  timestamp: pino.stdTimeFunctions.isoTime,
-});
+import logger from "./logger";
 
 /**
  * Node enviroment, used to load the corresponding .env file

--- a/src/config/locale.ts
+++ b/src/config/locale.ts
@@ -1,0 +1,11 @@
+import locale from "i18next";
+import enJSON from "../locale/en.json";
+
+locale.init({
+  resources: {
+    en: { ...enJSON },
+  },
+  lng: "en",
+});
+
+export default locale;

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -1,0 +1,19 @@
+import pino from "pino";
+
+/**
+ * Logger object for better log messages
+ */
+const logger = pino({
+  transport: {
+    targets: [
+      { target: "pino-pretty" },
+      {
+        target: "pino/file",
+        options: { destination: `.log` },
+      },
+    ],
+  },
+  timestamp: pino.stdTimeFunctions.isoTime,
+});
+
+export default logger;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { connect } from "mongoose";
 import { Telegraf } from "telegraf";
-import { BOT_TOKEN, DB_URL, logger } from "./config/env";
+import { BOT_TOKEN, DB_URL } from "./config/env";
+import logger from "./config/logger";
 
 const init = async () => {
   try {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1,0 +1,3 @@
+{
+  "translation": {}
+}


### PR DESCRIPTION
This PR adds locale support with i18next, and also move logger to its specific file (it was out of context in the `config/env.ts file`)