### PR TITLE
feat: define Event schema

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -1,0 +1,6 @@
+export enum Commands {
+  Start = "start",
+  Help = "help",
+  List = "list",
+  Add = "add",
+}

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -1,4 +1,6 @@
 import pino from "pino";
+import { Context } from "telegraf";
+import { Commands } from "../commands/commands";
 
 /**
  * Logger object for better log messages
@@ -6,7 +8,12 @@ import pino from "pino";
 const logger = pino({
   transport: {
     targets: [
-      { target: "pino-pretty" },
+      {
+        target: "pino-pretty",
+        options: {
+          ignore: "err,ctx",
+        },
+      },
       {
         target: "pino/file",
         options: { destination: `.log` },
@@ -15,5 +22,18 @@ const logger = pino({
   },
   timestamp: pino.stdTimeFunctions.isoTime,
 });
+
+/**
+ * Handle common command error
+ * @param cmd command name
+ * @param ctx Telegraf context object
+ * @param err Error object
+ */
+export const cmdError = (cmd: Commands, ctx: Context, err: unknown) => {
+  logger.error(
+    { err, ctx },
+    `Command /${cmd} raised an error. Seek .log file for more info.`,
+  );
+};
 
 export default logger;

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -1,6 +1,6 @@
 import pino from "pino";
 import { Context } from "telegraf";
-import { Commands } from "../commands/commands";
+import Cmd from "../types/cmd";
 
 /**
  * Logger object for better log messages
@@ -24,12 +24,12 @@ const logger = pino({
 });
 
 /**
- * Handle common command error
+ * Handles common command error
  * @param cmd command name
  * @param ctx Telegraf context object
  * @param err Error object
  */
-export const cmdError = (cmd: Commands, ctx: Context, err: unknown) => {
+export const cmdError = (cmd: Cmd, ctx: Context, err: unknown) => {
   logger.error(
     { err, ctx },
     `Command /${cmd} raised an error. Seek .log file for more info.`,

--- a/src/models/Event.ts
+++ b/src/models/Event.ts
@@ -1,5 +1,5 @@
 import { model, Schema } from "mongoose";
-import { TEvent } from "../types/event";
+import TEvent from "../types/event";
 import { interactions } from "../types/interaction";
 
 const schema = new Schema<TEvent>(
@@ -43,4 +43,6 @@ const schema = new Schema<TEvent>(
   },
 );
 
-export const MEvent = model<TEvent>("event", schema);
+const MEvent = model<TEvent>("event", schema);
+
+export default MEvent;

--- a/src/models/Event.ts
+++ b/src/models/Event.ts
@@ -1,0 +1,46 @@
+import { model, Schema } from "mongoose";
+import { TEvent } from "../types/event";
+import { interactions } from "../types/interaction";
+
+const schema = new Schema<TEvent>(
+  {
+    creator: { type: Number, required: true },
+    name: { type: String, minlength: 5, maxlength: 50, required: true },
+    description: { type: String, maxlength: 140, required: false },
+    locations: [
+      {
+        type: [{ type: Number, minlength: 2, maxlength: 2, required: true }],
+        default: [],
+        required: false,
+      },
+    ],
+    participants: [
+      {
+        type: {
+          user: { type: Number, required: true },
+          interaction: {
+            type: String,
+            enum: interactions,
+            required: true,
+          },
+        },
+        default: [],
+        required: true,
+      },
+    ],
+    dates: [
+      {
+        type: [{ type: Date, minlength: 1, maxlength: 2, required: true }],
+        default: [],
+        required: true,
+      },
+    ],
+  },
+  {
+    timestamps: true,
+    toJSON: { virtuals: true },
+    toObject: { virtuals: true },
+  },
+);
+
+export const MEvent = model<TEvent>("event", schema);

--- a/src/types/cmd.ts
+++ b/src/types/cmd.ts
@@ -1,6 +1,8 @@
-export enum Commands {
+enum Cmd {
   Start = "start",
   Help = "help",
   List = "list",
   Add = "add",
 }
+
+export default Cmd;

--- a/src/types/event.d.ts
+++ b/src/types/event.d.ts
@@ -1,0 +1,45 @@
+import { TInteraction } from "./interaction";
+
+export type TEvent = {
+  /**
+   * Unique identifier of the event
+   */
+  id: string;
+  /**
+   * Telegram user id of the creator of the event
+   */
+  creator: number;
+  /**
+   * Name of the event
+   * @minLenght 5
+   * @maxLenght 50
+   */
+  name: string;
+  /**
+   * Description of the event, markdown formatted
+   * @maxLenght 140
+   */
+  description?: string;
+  /**
+   * List of coordinates of the event
+   */
+  locations?: Array<[number, number]>;
+  /**
+   * List of Telegram user ids with the interaction to the event
+   */
+  participants: Array<TInteraction>;
+  /**
+   * List of dates of the event
+   */
+  dates: Array<[Date] | [Date, Date]>;
+  /**
+   * Date of creation of the event
+   */
+  createdAt: Date;
+  /**
+   * Date of update of the event
+   */
+  updatedAt: Date;
+};
+
+export type MockTEvent = Omit<TEvent, "id" | "createdAt" | "updatedAt">;

--- a/src/types/event.d.ts
+++ b/src/types/event.d.ts
@@ -1,6 +1,6 @@
-import { TInteraction } from "./interaction";
+import TInteraction from "./interaction";
 
-export type TEvent = {
+type TEvent = {
   /**
    * Unique identifier of the event
    */
@@ -43,3 +43,4 @@ export type TEvent = {
 };
 
 export type MockTEvent = Omit<TEvent, "id" | "createdAt" | "updatedAt">;
+export default TEvent;

--- a/src/types/event.d.ts
+++ b/src/types/event.d.ts
@@ -11,13 +11,13 @@ type TEvent = {
   creator: number;
   /**
    * Name of the event
-   * @minLenght 5
-   * @maxLenght 50
+   * @minLength 5
+   * @maxLength 50
    */
   name: string;
   /**
    * Description of the event, markdown formatted
-   * @maxLenght 140
+   * @maxLength 140
    */
   description?: string;
   /**

--- a/src/types/interaction.ts
+++ b/src/types/interaction.ts
@@ -1,4 +1,4 @@
-export type TInteraction = {
+type TInteraction = {
   /**
    * Telegram user id
    */
@@ -14,3 +14,5 @@ export const interactions = [
   "maybe",
   "not partecipate",
 ] as const;
+
+export default TInteraction;

--- a/src/types/interaction.ts
+++ b/src/types/interaction.ts
@@ -1,0 +1,16 @@
+export type TInteraction = {
+  /**
+   * Telegram user id
+   */
+  user: number;
+  /**
+   * Type of interaction with the event
+   */
+  interaction: (typeof interactions)[number];
+};
+
+export const interactions = [
+  "partecipate",
+  "maybe",
+  "not partecipate",
+] as const;


### PR DESCRIPTION
This PR creates the Event schema and type to handle events created by users on Telegram. This also creates Cmd to handle bot commands and Interaction, which is the interaction between a user and the event. This PR also adds a common function to handle the error log of a command failing and hides extra information about the error in the pino-pretty output.